### PR TITLE
chore: move generator version to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,1 @@
+FROM openapitools/openapi-generator-cli:v6.0.0

--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,11 @@ SHELL = bash
 GIT_USER_ID = libretime
 GIT_REPO_ID = client
 
-# https://github.com/OpenAPITools/openapi-generator/releases
-GENERATOR_VERSION = v6.0.0
 GENERATOR_CLI = docker run \
 	--rm \
 	--volume="$$PWD:/local" \
 	--user="$$UID:$$GID" \
-	openapitools/openapi-generator-cli:$(GENERATOR_VERSION)
+	$(shell docker build -q .)
 
 GENERATATE_CMD = $(GENERATOR_CLI) generate \
 		--input-spec /local/schema.yml \


### PR DESCRIPTION
Renovate will be able to open PR with newer openapi generator versions.